### PR TITLE
feat!: Add Terminal Query Pattern for compile-time query chain validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           npm version $BUMP_TYPE
           npm publish
         env:
-          NODE_TOKEN: ${{ secrets.NPM_TOKEN }} # Use NODE_AUTH_TOKEN for npm publish
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Push changes and tags
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           npm version $BUMP_TYPE
           npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} # Use NODE_AUTH_TOKEN for npm publish
+          NODE_TOKEN: ${{ secrets.NPM_TOKEN }} # Use NODE_AUTH_TOKEN for npm publish
       - name: Push changes and tags
         run: |
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -1,112 +1,58 @@
-# Hypergraph Storage
+# @hgraph/storage
 
-- [Hypergraph Storage](#hypergraph-storage)
-  - [Install](#install)
-  - [Usage](#usage)
-  - [Usage with NestJS (Recommended)](#usage-with-nestjs-recommended)
-    - [Step 1: Configure the `StorageModule` as a Root Module](#step-1-configure-the-storagemodule-as-a-root-module)
-    - [Step 2: Configure Entities in Feature Modules](#step-2-configure-entities-in-feature-modules)
-    - [Step 3: Use Repositories in Your Services](#step-3-use-repositories-in-your-services)
-  - [Usage without NestJS](#usage-without-nestjs)
-    - [Step 1: Initialize the Data Source](#step-1-initialize-the-data-source)
-    - [Step 2: Define a Repository Class](#step-2-define-a-repository-class)
-    - [Step 3: Get an Instance of the Repository](#step-3-get-an-instance-of-the-repository)
-    - [Step 4: Use Dependency Injection with Libraries like `tsyringe`](#step-4-use-dependency-injection-with-libraries-like-tsyringe)
-  - [Fetch Records](#fetch-records)
-    - [find](#find)
-    - [findById](#findbyid)
-    - [findByIds](#findbyids)
-    - [findAll](#findall)
-    - [findOne](#findone)
-  - [Query Builder](#query-builder)
-    - [Query](#query)
-    - [PaginatedQuery](#paginatedquery)
-    - [Terminal Query Pattern](#terminal-query-pattern)
-  - [Insert \& Update](#insert--update)
-    - [save](#save)
-    - [saveMany](#savemany)
-    - [insert](#insert)
-    - [insertMany](#insertmany)
-    - [update](#update)
-    - [updateMany](#updatemany)
-  - [Count](#count)
-  - [Increment](#increment)
-  - [Delete \& Restore](#delete--restore)
-  - [Using with Cloud Firestore](#using-with-cloud-firestore)
-    - [Using with NestJS](#using-with-nestjs)
-      - [Key Points:](#key-points)
-    - [Using without NestJS](#using-without-nestjs)
-      - [Key Points:](#key-points-1)
-    - [Additional Notes](#additional-notes)
-    - [Queries](#queries)
-    - [Modification API](#modification-api)
-  - [Using Cache](#using-cache)
-  - [TypeORM DataSource](#typeorm-datasource)
-  - [Testing](#testing)
-    - [Testing with firestore](#testing-with-firestore)
+A powerful, type-safe database abstraction layer built on TypeORM with first-class TypeScript support.
 
-This is a package for accessing databases using TypeORM, that comes with the following benefits:
+[![npm version](https://img.shields.io/npm/v/@hgraph/storage.svg)](https://www.npmjs.com/package/@hgraph/storage)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-- Built for TypeScript and typing support
-- Works best with GraphQL especially libraries like [TypeGraphQL](https://typegraphql.com/)
-- Comes with easy to use [Query](#query-builder) builder with elegant and convenient syntax with
-  typing support
-- Supports pagination through [PaginatedQuery](#paginatedquery) builder
-- Built on top of [TypeORM](https://typeorm.io/), hence comes with all the benefits that it
-  provides:
-  - Supports MySQL / MariaDB / Postgres / CockroachDB / SQLite / Microsoft SQL Server / Oracle / SAP
-    Hana / sql.js.
-  - Works in NodeJS / Browser / Ionic / Cordova / React Native / NativeScript / Expo / Electron
-    platforms.
-  - Entities and columns.
-  - Database-specific column types.
-  - Entity manager.
-  - Clean object relational model.
-  - Associations (relations).
-  - Eager and lazy relations.
-  - Uni-directional, bi-directional and self-referenced relations.
-  - Supports multiple inheritance patterns.
-  - Cascades.
-  - Indices.
-  - Transactions.
-  - Migrations and automatic migrations generation.
-  - Connection pooling.
-  - Replication.
-  - Using multiple database instances.
-  - Working with multiple databases types.
-  - Cross-database and cross-schema queries.
-  - Left and inner joins.
-  - Proper pagination for queries using joins.
-  - Query caching.
-  - Streaming raw results.
-  - Logging.
-  - Listeners and subscribers (hooks).
-  - Supports MongoDB NoSQL database.
-  - TypeScript and JavaScript support.
-  - ESM and CommonJS support.
-  - Produced code is performant, flexible, clean and maintainable.
+## Why @hgraph/storage?
 
-## Install
+- **Type-Safe Query Builder** - Catch query errors at compile time, not runtime
+- **Elegant API** - Fluent, chainable methods that read like natural language
+- **Framework Flexible** - Works seamlessly with NestJS or standalone
+- **Multi-Database Support** - PostgreSQL, MySQL, SQLite, SQL Server, Oracle, and Cloud Firestore
+- **Built-in Pagination** - First-class support for cursor-based pagination
+- **GraphQL Ready** - Optimized for GraphQL with DataLoader caching support
 
-Using npm:
+## Table of Contents
 
-```sh
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Usage with NestJS](#usage-with-nestjs)
+- [Usage without NestJS](#usage-without-nestjs)
+- [Query Builder](#query-builder)
+  - [Basic Queries](#basic-queries)
+  - [Where Conditions](#where-conditions)
+  - [Text Search](#text-search)
+  - [Array Operations](#array-operations)
+  - [Relations and Joins](#relations-and-joins)
+  - [Sorting and Pagination](#sorting-and-pagination)
+  - [Terminal Query Pattern](#terminal-query-pattern)
+- [CRUD Operations](#crud-operations)
+  - [Fetching Records](#fetching-records)
+  - [Creating and Updating](#creating-and-updating)
+  - [Counting Records](#counting-records)
+  - [Incrementing Values](#incrementing-values)
+  - [Deleting and Restoring](#deleting-and-restoring)
+- [Cloud Firestore](#cloud-firestore)
+- [Caching with DataLoader](#caching-with-dataloader)
+- [Testing](#testing)
+- [Advanced Usage](#advanced-usage)
+
+## Installation
+
+```bash
 npm install @hgraph/storage
-```
-
-Using yarn:
-
-```sh
+# or
 yarn add @hgraph/storage
 ```
 
-## Usage
+## Quick Start
 
-Define entity class. See [this](docs/entities.md) for more examples.
+### 1. Define Your Entity
 
-```ts
-import { Repository } from '@hgraph/storage'
-import { Column, PrimaryColumn } from 'typeorm'
+```typescript
+import { Entity, Column, PrimaryColumn } from 'typeorm'
 
 @Entity()
 class User {
@@ -117,79 +63,84 @@ class User {
   name!: string
 
   @Column()
-  username!: string
+  email!: string
 
   @Column({ nullable: true })
   bio?: string
 
-  @Column({ nullable: true })
+  @Column({ default: false })
   verified?: boolean
 
-  @Column({ nullable: true })
+  @Column({ default: 0 })
   followers?: number
 }
 ```
 
-## Usage with NestJS (Recommended)
+### 2. Create a Repository
 
-To integrate the `StorageModule` into your NestJS application effectively, follow the steps below.
-The `StorageModule` provides a convenient way to manage repositories and entities within your NestJS
-ecosystem. For more information on NestJS modules, refer to the
-[NestJS Module Documentation](https://docs.nestjs.com/modules).
+```typescript
+import { Repository } from '@hgraph/storage'
 
-### Step 1: Configure the `StorageModule` as a Root Module
+class UserRepository extends Repository<User> {
+  constructor() {
+    super(User)
+  }
+}
+```
 
-Begin by setting up the `StorageModule` in your root module (commonly `AppModule`). This
-configuration initializes the storage layer and connects to the database using parameters from your
-environment configuration:
+### 3. Query Your Data
 
-```ts
+```typescript
+const userRepo = new UserRepository()
+
+// Find users with elegant query syntax
+const activeUsers = await userRepo.findAll(q =>
+  q.whereEqualTo('verified', true)
+   .whereMoreThan('followers', 100)
+   .orderByDescending('followers')
+)
+```
+
+## Usage with NestJS
+
+### Step 1: Configure Root Module
+
+```typescript
 import { Module } from '@nestjs/common'
 import { StorageModule, RepositoryType } from '@hgraph/storage/nestjs'
-import { AppController } from './app.controller'
-import { UserModule } from './user/user.module'
-import { AuthModule } from './auth/auth.module'
-import config from './config'
 
 @Module({
   imports: [
     StorageModule.forRoot({
-      repositoryType: RepositoryType.TypeORM, // Specify the repository type (e.g., TypeORM).
-      url: config.DATABASE_URL, // Database connection URL.
-      type: config.DATABASE_TYPE as any, // Database type (e.g., PostgreSQL, MySQL).
-      synchronize: config.DB_SYNCHRONIZE, // Synchronize schema with the database.
+      repositoryType: RepositoryType.TypeORM,
+      type: 'postgres',
+      url: process.env.DATABASE_URL,
+      synchronize: process.env.NODE_ENV === 'development',
     }),
-    UserModule, // Import your feature modules.
-    AuthModule,
+    UserModule,
   ],
-  controllers: [AppController],
 })
 export class AppModule {}
 ```
 
-### Step 2: Configure Entities in Feature Modules
+### Step 2: Register Entities in Feature Modules
 
-Each feature module should declare its entities to be managed by the `StorageModule`. This ensures
-that the necessary database schema and repository are available within the scope of the feature
-module:
-
-```ts
+```typescript
 import { Module } from '@nestjs/common'
 import { StorageModule } from '@hgraph/storage/nestjs'
 import { User } from './user.entity'
+import { UserService } from './user.service'
 
 @Module({
-  imports: [StorageModule.forFeature([User])], // Declare entities specific to this module.
+  imports: [StorageModule.forFeature([User])],
+  providers: [UserService],
 })
-export class CustomModule {}
+export class UserModule {}
 ```
 
-### Step 3: Use Repositories in Your Services
+### Step 3: Inject Repositories
 
-Once the `StorageModule` is configured, you can inject repositories into your services using the
-`@InjectRepo` decorator. This simplifies access to your database operations:
-
-```ts
+```typescript
 import { Injectable } from '@nestjs/common'
 import { InjectRepo, Repository } from '@hgraph/storage/nestjs'
 import { User } from './user.entity'
@@ -197,714 +148,386 @@ import { User } from './user.entity'
 @Injectable()
 export class UserService {
   constructor(
-    @InjectRepo(User) // Inject the repository for the User entity.
-    private readonly userRepository: Repository<User>,
+    @InjectRepo(User)
+    private readonly userRepo: Repository<User>,
   ) {}
 
-  // Example method for retrieving all users.
-  async findAll(): Promise<User[]> {
-    return this.userRepository.find()
+  async findVerifiedUsers(): Promise<User[]> {
+    return this.userRepo.findAll(q => q.whereEqualTo('verified', true))
   }
 }
 ```
-
-By following these steps, you can seamlessly manage your application’s data layer using the
-`StorageModule` while adhering to NestJS’s modular architecture.
 
 ## Usage without NestJS
 
-To use this library independently of NestJS, follow these steps to initialize your data source,
-configure repositories, and integrate dependency injection if required.
+### Initialize the Data Source
 
-### Step 1: Initialize the Data Source
-
-You can initialize the data source programmatically using the `initializeDataSource` function.
-Specify the database type, connection URL, and synchronization settings:
-
-```ts
+```typescript
 import { initializeDataSource } from '@hgraph/storage'
 
 await initializeDataSource({
-  type: process.env.DATABASE_TYPE as any, // Specify the database type (e.g., postgres, mysql).
-  url: process.env.DATABASE_URL, // Database connection URL.
-  synchronize: process.env.DB_SYNCHRONIZE, // Synchronize schema with the database.
+  type: 'postgres',
+  url: process.env.DATABASE_URL,
+  entities: [User, Post, Comment],
+  synchronize: true,
 })
 ```
 
-Alternatively, use environment variables to configure the database connection. This approach
-simplifies deployment and avoids hardcoding sensitive information:
+Or use environment variables:
 
-```sh
+```bash
 DATABASE_TYPE=postgres
-DATABASE_URL=<database_type>://<username>:<password>@<host>:<port>/<database_name>
-DATABASE_SYNCHRONIZE="true"
+DATABASE_URL=postgres://user:pass@localhost:5432/mydb
+DATABASE_SYNCHRONIZE=true
 ```
 
-Then initialize the data source with the specified entities:
+### Use with Dependency Injection (tsyringe)
 
-```ts
-await initializeDataSource({
-  entities: [User], // Declare your application entities.
-})
-```
-
-### Step 2: Define a Repository Class
-
-Create a custom repository class for managing your entities. This class extends the base
-`Repository` class and specifies the entity type:
-
-```ts
-import { Repository } from '@hgraph/storage'
-import { User } from './user.entity'
-
-class UserRepository extends Repository<User> {
-  constructor() {
-    super(User) // Initialize the repository with the User entity.
-  }
-}
-```
-
-### Step 3: Get an Instance of the Repository
-
-To interact with the `UserRepository`, create an instance of the repository. This allows you to
-perform database operations:
-
-```ts
-const userRepository = new UserRepository()
-```
-
-### Step 4: Use Dependency Injection with Libraries like `tsyringe`
-
-If you’re using a dependency injection library such as
-[`tsyringe`](https://www.npmjs.com/package/tsyringe), you can manage repository instances
-efficiently. This approach is especially useful for caching and GraphQL integrations:
-
-```ts
+```typescript
 import { container } from 'tsyringe'
 
-const userRepository = container.resolve(UserRepository) // Resolve the repository from the DI container.
-```
-
-By following these steps, you can configure and use the this library outside of a NestJS application
-while maintaining flexibility and scalability.
-
-## Fetch Records
-
-The repository class comes with `.find*` methods that you can use to query data using
-[`Query`](#query-builder) builder:
-
-- [find](#find)
-- [findById](#findbyid)
-- [findByIds](#findbyids)
-- [findAll](#findall)
-- [findOne](#findone)
-
-### find
-
-You can fetch multiple records from a table using `find` method. This method supports pagination.
-
-```ts
-// find using a query, but paginate
-const { next, items } = await userRepository.find(query =>
-  query.whereEqualTo('name', 'John Doe').next(nextTokenFromBefore).limit(200),
-)
-```
-
-will execute the following sql query and return first `200` records and a `next` token that you can
-use for next page. `OFFSET` will be calculated from `nextTokenFromBefore`
-
-```sql
-SELECT * FROM "user"
-WHERE "name" = 'John Doe'
-OFFSET <OFFSET>
-LIMIT 200
-```
-
-### findById
-
-You can query a record by id directly using `findById` method.
-
-```ts
-const user = await userRepository.findById('user1')
-```
-
-will execute a query
-
-```sql
-SELECT * FROM "user"
-WHERE "id" = 'user1'
-```
-
-### findByIds
-
-You can find more than one record by its ids by using `findByIds`.
-
-```ts
-// find many by ids
-const users = await userRepository.findByIds(['user1', 'user2'])
-```
-
-will execute a query
-
-```sql
-SELECT * FROM "user"
-WHERE "id" IN ('user1', 'user2')
-```
-
-### findAll
-
-You can use `findAll` to get all records without pagination. This method provides support for in
-memory filter and pagination callback.
-
-```ts
-// find all from the entity table
-const users = await userRepository.findAll()
-
-// find all using a query
-const users = await userRepository.findAll(query => query.whereEqualTo('name', 'John Doe'))
-
-// find all using a query, filter and a pagination callback
-const users = await userRepository.findAll(
-  query => query.whereEqualTo('name', 'John Doe'),
-  item => someLogicToFilter(item),
-  (items, next) => console.log('fetched a page', items, next),
-)
-```
-
-### findOne
-
-This method works just like `findAll` but returns only the first record.
-
-```ts
-// find one from the top
-const user = await userRepository.findOne()
-
-// find one using a query
-const user = await userRepository.findOne(query => query.whereEqualTo('name', 'John Doe'))
+const userRepo = container.resolve(UserRepository)
+const users = await userRepo.findAll()
 ```
 
 ## Query Builder
 
-Query class provides an easy to use implementation for constructing complex SQL query. It allows you
-to build SQL queries using elegant and convenient syntax with typing support. Here is the
-[entity setup](docs/entities.md) for this example.
+The query builder provides a fluent, type-safe API for constructing database queries.
 
-### Query
+### Basic Queries
 
-```ts
-import { Query } from '@hgraph/storage'
+```typescript
+import { Query, PaginatedQuery } from '@hgraph/storage'
 
-const repo = new UserRepository()
-const query = new Query(repo)
+// Simple query with repository methods
+const user = await userRepo.findOne(q =>
+  q.whereEqualTo('email', 'john@example.com')
+)
 
-  // select columns
-  .select('bio')
-  .select('id')
-  .select('email')
-
-  // where conditions
-  .whereEqualTo('id', 'id1')
-  .whereNotEqualTo('id', 'id1')
-
-  // numeric checks
-  .whereMoreThan('version', 1)
-  .whereMoreThanOrEqual('version', 1)
-  .whereLessThan('version', 1)
-  .whereLessThanOrEqual('version', 1)
-  .whereBetween('version', 1, 2)
-
-  // numeric "NOT" operators
-  .whereNotMoreThan('version', 1)
-  .whereNotMoreThanOrEqual('version', 1)
-  .whereNotLessThan('version', 0)
-  .whereNotLessThanOrEqual('version', 1)
-
-  // search
-  .whereTextContains('bio', 'true')
-  .whereTextStartsWith('bio', 'any')
-  .whereTextEndsWith('bio', 'any')
-
-  // case insensitive search
-  .whereTextInAnyCaseContains('bio', 'any')
-  .whereTextInAnyCaseStartsWith('bio', 'any')
-  .whereTextInAnyCaseEndsWith('bio', 'any')
-
-  // "IN" operator
-  .whereIn('role', [UserRole.ADMIN, UserRole.USER])
-
-  // null checks
-  .whereIsNull('name')
-  .whereIsNotNull('name')
-
-  // array operations
-  .whereArrayContains('tags', 'new')
-  .whereArrayContainsAny('tags', ['new', 'trending'])
-
-  // search on related tables
-  .whereJoin('photos', q => q.whereIsNotNull('url'))
-
-  // build "OR" condition
-  .whereOr(
-    query => query.whereEqualTo('id', '10'),
-    query => query.whereEqualTo('id', '10'),
-  )
-
-  // sort
-  .orderByAscending('version')
-  .orderByDescending('createdAt')
-
-  // fetch related entities
-  .fetchRelation('photos', 'album')
-  .loadRelationIds() // load only 'id', not required with `fetchRelation`
-
-  // enable or set timeout for `cache`
-  .cache(5000 ?? true)
+// Paginated query
+const { items, next } = await userRepo.find(q =>
+  q.whereEqualTo('verified', true)
+   .limit(20)
+   .next(previousToken)
+)
 ```
 
-### PaginatedQuery
+### Where Conditions
 
-`PaginatedQuery`, in addition to the following, supports all the methods in `Query`.
+```typescript
+// Equality
+q.whereEqualTo('status', 'active')
+q.whereNotEqualTo('status', 'deleted')
 
-```ts
-import { PaginatedQuery } from '@hgraph/storage'
+// Comparisons
+q.whereMoreThan('age', 18)
+q.whereMoreThanOrEqual('score', 100)
+q.whereLessThan('price', 50)
+q.whereLessThanOrEqual('quantity', 10)
+q.whereBetween('rating', 3, 5)
 
-const repo = new UserRepository()
-const query = new PaginatedQuery(repo)
+// Negated comparisons
+q.whereNotMoreThan('attempts', 3)
+q.whereNotLessThan('balance', 0)
 
-  // use individual methods
-  .next('token')
-  .limit(10)
+// Null checks
+q.whereIsNull('deletedAt')
+q.whereIsNotNull('verifiedAt')
 
-  // or use this method
-  .pagination({ next: 'token', limit: 10 })
+// IN operator
+q.whereIn('role', ['admin', 'moderator'])
+
+// OR conditions
+q.whereOr(
+  q1 => q1.whereEqualTo('role', 'admin'),
+  q2 => q2.whereEqualTo('role', 'superuser')
+)
+```
+
+### Text Search
+
+```typescript
+// Partial matches
+q.whereTextContains('bio', 'developer')      // LIKE '%developer%'
+q.whereTextStartsWith('name', 'John')        // LIKE 'John%'
+q.whereTextEndsWith('email', '@gmail.com')   // LIKE '%@gmail.com'
+
+// Case-insensitive search
+q.whereTextInAnyCaseContains('title', 'urgent')
+q.whereTextInAnyCaseStartsWith('name', 'john')
+q.whereTextInAnyCaseEndsWith('domain', '.COM')
+```
+
+### Array Operations
+
+```typescript
+// Check if array contains value
+q.whereArrayContains('tags', 'featured')
+
+// Check if array contains any of the values
+q.whereArrayContainsAny('categories', ['tech', 'science'])
+```
+
+### Relations and Joins
+
+```typescript
+// Filter by related entity
+q.whereJoin('posts', postQuery =>
+  postQuery.whereEqualTo('published', true)
+)
+
+// Fetch related entities
+q.fetchRelation('posts', 'comments', 'author')
+
+// Load only relation IDs (performance optimization)
+q.loadRelationIds()
+```
+
+### Sorting and Pagination
+
+```typescript
+// Sorting
+q.orderByAscending('name')
+q.orderByDescending('createdAt')
+
+// Pagination
+q.limit(25)
+q.next('cursor-token')
+
+// Combined
+q.pagination({ limit: 25, next: 'cursor-token' })
+
+// Select specific columns
+q.select('id', 'name', 'email')
+
+// Enable caching
+q.cache(5000) // Cache for 5 seconds
 ```
 
 ### Terminal Query Pattern
 
-To prevent "Unsupported FindOperator" runtime errors from TypeORM, the query builder enforces safe
-ordering using a **Terminal Query Pattern**. Certain methods (`whereIn` and `whereOr`) return a
-`TerminalQuery` that only exposes safe methods.
+To prevent TypeORM runtime errors, certain methods (`whereIn` and `whereOr`) must be called last. The type system enforces this at compile time:
 
-#### Rules
-
-1. **`whereIn` must be last** - No other where methods can be chained after it.
-
-```ts
-// CORRECT
+```typescript
+// CORRECT: whereIn is last
 q.whereEqualTo('status', 'active')
+ .orderByDescending('createdAt')
  .whereIn('groupId', groupIds)
 
-// COMPILE ERROR
+// COMPILE ERROR: can't chain after whereIn
 q.whereIn('groupId', groupIds)
  .whereEqualTo('status', 'active')  // TypeScript error!
 ```
 
-2. **`whereOr` must be last** - Same restriction applies.
+**Rules:**
+1. `whereIn` must be the last where condition
+2. `whereOr` must be the last where condition
+3. Never use `whereIn` inside `whereJoin` or `whereOr`
 
-```ts
-// CORRECT
-q.whereEqualTo('status', 'active')
- .whereOr(
-   q1 => q1.whereEqualTo('role', 'admin'),
-   q2 => q2.whereEqualTo('role', 'mod')
- )
-
-// COMPILE ERROR
-q.whereOr(...)
- .whereEqualTo('status', 'active')  // TypeScript error!
-```
-
-3. **Never use `whereIn` inside `whereJoin`** - Throws runtime error.
-
-```ts
-// RUNTIME ERROR
-q.whereJoin('group', gq => gq.whereIn('id', groupIds))
-
-// CORRECT - use explicit foreign key
-q.whereIn('groupId', groupIds)
-```
-
-4. **Never use `whereIn` inside `whereOr`** - Throws runtime error.
-
-```ts
-// RUNTIME ERROR
-q.whereOr(q1 => q1.whereIn('status', ['a', 'b']), ...)
-
-// CORRECT - use multiple whereEqualTo
-q.whereOr(
-  q1 => q1.whereEqualTo('status', 'a'),
-  q2 => q2.whereEqualTo('status', 'b')
-)
-```
-
-#### Safe Methods After Terminal Operations
-
-After `whereIn()` or `whereOr()`, you can still chain:
-
-- `orderByAscending()` / `orderByDescending()`
-- `select()`, `fetchRelation()`, `loadRelationIds()`
-- `cache()`, `toQuery()`
-- For paginated: `limit()`, `next()`, `pagination()`
+After terminal operations, you can still chain: `orderBy*`, `select`, `fetchRelation`, `limit`, `next`, `cache`.
 
 See [docs/query-builder.md](docs/query-builder.md) for complete documentation.
 
-## Insert & Update
+## CRUD Operations
 
-You can insert and update records using the following methods:
+### Fetching Records
 
-- [save](#save)
-- [saveMany](#savemany)
-- [insert](#insert)
-- [insertMany](#insertmany)
-- [update](#update)
-- [updateMany](#updatemany)
+```typescript
+// Find by ID
+const user = await userRepo.findById('user-123')
 
-### save
+// Find by multiple IDs
+const users = await userRepo.findByIds(['user-1', 'user-2', 'user-3'])
 
-This method will insert if the `id` (if provided) does not exist in the database, or will update the
-existing record.
+// Find one with query
+const admin = await userRepo.findOne(q =>
+  q.whereEqualTo('role', 'admin')
+)
 
-```ts
-const user = await userRepository.save({ id: 'user1', name: 'John Doe', username: 'johnd' })
-```
+// Find all (no pagination)
+const allUsers = await userRepo.findAll()
 
-### saveMany
+// Find all with query and filter
+const filteredUsers = await userRepo.findAll(
+  q => q.whereEqualTo('verified', true),
+  user => user.followers > 1000,  // In-memory filter
+  (items, next) => console.log(`Fetched ${items.length} users`)  // Progress callback
+)
 
-You can insert or update more than one record using in a step using `saveMany`. Just like `save` the
-record will inserted if `id` does not record.
-
-```ts
-const users = await userRepository.saveMany([
-  { id: 'user1', name: 'John Doe', username: 'johndoe' },
-  { id: 'user2', name: 'Mejia Henderso', username: 'mh' },
-])
-```
-
-### insert
-
-You can insert a record using `insert` method. "id" will be auto populated, if omitted.
-
-```ts
-const user = await userRepository.insert({ name: 'John Done', username: 'johndoe' })
-```
-
-### insertMany
-
-You can insert multiple users at once using `insertMany`.
-
-```ts
-const users = await userRepository.insertMany([
-  { name: 'John Doe', username: 'johndoe' },
-  { name: 'Mejia Henderso', username: 'mh' },
-])
-```
-
-### update
-
-Use this method to update a record, "id" is mandatory input.
-
-```ts
-const user = await userRepository.update({ id: 'user1', username: 'john' })
-```
-
-### updateMany
-
-You can update more than one record using a query using `updateMany`.
-
-```ts
-// update multiple records at once using a query
-const users = await userRepository.updateMany(query => query.whereEqualTo('username', 'johndoe'), {
-  verified: true,
-})
-```
-
-## Count
-
-This method counts entities that match query (if provided) and returns a numeric value.
-
-```ts
-// count all users
-const count = await userRepository.count()
-
-// count all users with a query
-const count = await userRepository.count(query => query.whereEqualTo('name', 'John Doe'))
-```
-
-## Increment
-
-You can increment or decrement the value of a numeric column using an id or a query using this
-method.
-
-```ts
-// increment by id
-const user = await userRepository.increment('user1', 'followers', 1)
-
-// decrement by id
-const user = await userRepository.increment('user1', 'followers', -1)
-
-// increment by query
-const user = await userRepository.increment(
-  query => query.whereEqualTo('name', 'John Doe'),
-  'followers',
-  1,
+// Find with pagination
+const { items, next } = await userRepo.find(q =>
+  q.whereEqualTo('active', true)
+   .limit(50)
 )
 ```
 
-## Delete & Restore
+### Creating and Updating
 
-You can permanently delete a record from the table using `delete`. Alternatively you may choose to
-use soft delete by passing `{ softDelete: true }` option. This will keep the record in the table,
-however will populate `deletedAt` column with the current time stamp. TypeORM will inject
-`"deletedAt" IS NULL` to all queries by default, thus eliminating any records that were soft
-deleted. `restore` will remove `deletedAt` value.
+```typescript
+// Insert (auto-generates ID if omitted)
+const newUser = await userRepo.insert({
+  name: 'Jane Doe',
+  email: 'jane@example.com'
+})
 
-```ts
-// delete a user
-await userRepository.delete('user1') // delete by id
-await userRepository.delete(query => query.whereEqualTo('verified', false)) // delete by query
+// Insert multiple
+const users = await userRepo.insertMany([
+  { name: 'User 1', email: 'user1@example.com' },
+  { name: 'User 2', email: 'user2@example.com' }
+])
 
-// soft delete a user
-await userRepository.delete('user1', { softDelete: true }) // soft delete by id
-await userRepository.delete(query => query.whereEqualTo('verified', false), { softDelete: true }) // soft delete by query
+// Save (insert or update based on ID)
+const user = await userRepo.save({
+  id: 'user-123',
+  name: 'Updated Name'
+})
 
-// restore a user if soft deleted
-await userRepository.restore('user1') // restore by id
-await userRepository.restore(query => query.whereEqualTo('verified', false)) // restore by query
+// Save multiple
+await userRepo.saveMany([...users])
+
+// Update (ID required)
+const updated = await userRepo.update({
+  id: 'user-123',
+  verified: true
+})
+
+// Update multiple by query
+await userRepo.updateMany(
+  q => q.whereEqualTo('status', 'pending'),
+  { status: 'active' }
+)
 ```
 
----
+### Counting Records
 
-## Using with Cloud Firestore
+```typescript
+// Count all
+const total = await userRepo.count()
 
-This library offers robust support for
-[Cloud Firestore](https://firebase.google.com/docs/firestore), making it easier to integrate with
-your applications. Whether you are using NestJS or a standalone setup, this guide will walk you
-through the initialization process and demonstrate how to configure the data source and repositories
-for seamless integration. Most APIs provided by this library are designed to be compatible with each
-other, ensuring a consistent development experience.
+// Count with query
+const verifiedCount = await userRepo.count(q =>
+  q.whereEqualTo('verified', true)
+)
+```
 
-### Using with NestJS
+### Incrementing Values
 
-If you're working with NestJS, integrating this library is straightforward. The following example
-demonstrates how to set up the `StorageModule` with Firestore as the repository type. Ensure you
-have your Firebase service account configuration and storage bucket details ready:
+```typescript
+// Increment by ID
+await userRepo.increment('user-123', 'followers', 1)
+
+// Decrement by ID
+await userRepo.increment('user-123', 'followers', -1)
+
+// Increment by query
+await userRepo.increment(
+  q => q.whereEqualTo('featured', true),
+  'views',
+  1
+)
+```
+
+### Deleting and Restoring
+
+```typescript
+// Hard delete
+await userRepo.delete('user-123')
+
+// Delete by query
+await userRepo.delete(q =>
+  q.whereEqualTo('status', 'spam')
+)
+
+// Soft delete (sets deletedAt timestamp)
+await userRepo.delete('user-123', { softDelete: true })
+
+// Restore soft-deleted record
+await userRepo.restore('user-123')
+
+// Restore by query
+await userRepo.restore(q =>
+  q.whereEqualTo('status', 'suspended')
+)
+```
+
+## Cloud Firestore
+
+@hgraph/storage provides robust support for Google Cloud Firestore as an alternative to SQL databases.
+
+### Installation
+
+```bash
+npm install firebase-admin
+```
+
+### With NestJS
 
 ```typescript
 import { Module } from '@nestjs/common'
-import { StorageModule, RepositoryType } from '@hgraph/storage'
-import { UserModule } from './user/user.module'
-import { AuthModule } from './auth/auth.module'
-import { AppController } from './app.controller'
+import { StorageModule, RepositoryType } from '@hgraph/storage/nestjs'
 
 @Module({
   imports: [
     StorageModule.forRoot({
-      repositoryType: RepositoryType.Firestore, // Specify Firestore as the repository type
-      serviceAccountConfig: process.env.FIREBASE_SERVICE_ACCOUNT, // Path or JSON object containing your service account details
-      storageBucket: process.env.FIREBASE_STORAGE_BUCKET, // Optional: Specify your Firebase Storage bucket
+      repositoryType: RepositoryType.Firestore,
+      serviceAccountConfig: process.env.FIREBASE_SERVICE_ACCOUNT,
+      storageBucket: process.env.FIREBASE_STORAGE_BUCKET, // Optional
     }),
-    UserModule, // Import additional modules as needed
-    AuthModule,
   ],
-  controllers: [AppController], // Define application controllers
 })
 export class AppModule {}
 ```
 
-#### Key Points:
-
-- Replace `process.env.FIREBASE_SERVICE_ACCOUNT` with the appropriate path or JSON content for your
-  Firebase service account.
-- The `storageBucket` parameter is optional but can be included if your application uses Firebase
-  Storage.
-
-### Using without NestJS
-
-For non-NestJS applications, you can initialize the Firestore data source and define repositories
-directly. This provides flexibility for various use cases:
+### Without NestJS
 
 ```typescript
 import { initializeFirestore, FirestoreRepository } from '@hgraph/storage'
 
-// Initialize Firestore with service account configuration
 await initializeFirestore({
-  serviceAccountConfig: 'string', // Path to the JSON file containing your service account configuration
+  serviceAccountConfig: './service-account.json'
 })
 
-// Define a repository for a specific entity
-export class UserRepository extends FirestoreRepository<UserEntity> {
+class UserRepository extends FirestoreRepository<User> {
   constructor() {
-    super(UserEntity) // Pass the entity class to the repository
+    super(User)
   }
 }
 ```
 
-#### Key Points:
+### Firestore-Specific Operations
 
-- Ensure the `serviceAccountConfig` points to a valid Firebase service account JSON file.
-- Extend `FirestoreRepository` to create custom repositories for your entities, making it easier to
-  manage Firestore collections.
-
-### Additional Notes
-
-- Ensure you have installed the necessary Firebase SDK and dependencies before proceeding.
-- Always validate your service account credentials and configurations to avoid runtime errors.
-- For more advanced usage, refer to the library’s API documentation and Firestore’s official
-  guidelines.
-
-```sh
-npm install firebase-admin
-```
-
----
-
-### Queries
-
-The following apis are supported
-
-```ts
-import { FirestoreQuery } from '@hgraph/storage'
-
-const repo = new UserRepository()
-const query = new FirestoreQuery(repo)
-
-  // select columns
-  .select('bio')
-  .select('id')
-  .select('email')
-
-  // where conditions
-  .whereEqualTo('id', 'id1')
-  .whereNotEqualTo('id', 'id1')
-
-  // numeric checks
-  .whereMoreThan('version', 1)
-  .whereMoreThanOrEqual('version', 1)
-  .whereLessThan('version', 1)
-  .whereLessThanOrEqual('version', 1)
-  .whereBetween('version', 1, 2)
-
-  // numeric "NOT" operators
-  .whereNotMoreThan('version', 1)
-  .whereNotMoreThanOrEqual('version', 1)
-  .whereNotLessThan('version', 0)
-  .whereNotLessThanOrEqual('version', 1)
-
-  // search
-  // .whereTextContains('bio', 'true')                    // NOT SUPPORTED
-  .whereTextStartsWith('bio', 'any')
-  // .whereTextEndsWith('bio', 'any')                     // NOT SUPPORTED
-
-  // case insensitive search
-  // .whereTextInAnyCaseContains('bio', 'any')            // NOT SUPPORTED
-  // .whereTextInAnyCaseStartsWith('bio', 'any')          // NOT SUPPORTED
-  // .whereTextInAnyCaseEndsWith('bio', 'any')            // NOT SUPPORTED
-
-  // "IN" operator
-  .whereIn('role', [UserRole.ADMIN, UserRole.USER])
-
-  // null checks
-  .whereIsNull('name')
-  .whereIsNotNull('name')
-
-  // array operations
-  .whereArrayContains('tags', 'new')
-  .whereArrayContainsAny('tags', ['new', 'trending'])
-
-  // search on related tables
-  // .whereJoin('photos', q => q.whereIsNotNull('url'))   // NOT SUPPORTED YET
-
-  // build "OR" condition
-  .whereOr(
-    query => query.whereEqualTo('id', '10'),
-    query => query.whereEqualTo('id', '10'),
-  )
-
-  // sort
-  .orderByAscending('version')
-  .orderByDescending('createdAt')
-
-  // fetch related entities
-  // .fetchRelation('photos', 'album')                 // NOT SUPPORTED YET
-  .loadRelationIds()
-
-  // enable or set timeout for `cache`
-  .cache(5000 ?? true) // NOT EFFECT
-```
-
-### Modification API
-
-```ts
-// save a user
-const user = await userRepository.save({ id: 'user1', name: 'John Doe', username: 'johnd' })
-
-// save multiple users
-const users = await userRepository.saveMany([
-  { id: 'user1', name: 'John Doe', username: 'johndoe' },
-  { id: 'user2', name: 'Mejia Henderso', username: 'mh' },
-])
-
-// update a user
-const user = await userRepository.update({ id: 'user1', username: 'john' })
-
-// update multiple records at once using a query
-const users = await userRepository.updateMany(query => query.whereEqualTo('username', 'johndoe'), {
-  verified: true,
+```typescript
+// Add to array field
+await userRepo.addToArray('following', {
+  id: 'user-456',
+  name: 'Jane'
 })
 
-// count all users
-const count = await userRepository.count()
-
-// count all users with a query
-const count = await userRepository.count(query => query.whereEqualTo('name', 'John Doe'))
-
-// increment by id
-const user = await userRepository.increment('user1', 'followers', 1)
-
-// decrement by id
-const user = await userRepository.increment('user1', 'followers', -1)
-
-// increment by query
-const user = await userRepository.increment(
-  query => query.whereEqualTo('name', 'John Doe'),
-  'followers',
-  1,
-)
-
-// safest way to add an entity to an array "following" is as below
-const user = await userRepository.addToArray('following', {
-  id: 'user2',
-  name: 'Mejia Henderso',
-  username: 'mh',
+// Remove from array field
+await userRepo.removeFromArray('following', {
+  id: 'user-456'
 })
-
-// safest way to remove an entity from an array "following" is as below
-const user = await userRepository.removeFromArray('following', {
-  id: 'user2',
-  name: 'Mejia Henderso',
-  username: 'mh',
-})
-
-// delete a user
-await userRepository.delete('user1') // delete by id
-await userRepository.delete(query => query.whereEqualTo('verified', false)) // delete by query
-
-// soft delete a user - NOT SUPPORTED
-// await userRepository.delete('user1', { softDelete: true }) // soft delete by id
-// await userRepository.delete(query => query.whereEqualTo('verified', false), { softDelete: true }) // soft delete by query
-
-// restore a user if soft deleted - NOT SUPPORTED YET
-// await userRepository.restore('user1') // restore by id
-// await userRepository.restore(query => query.whereEqualTo('verified', false)) // restore by query
 ```
 
-## Using Cache
+### Firestore Query Limitations
 
-Id cache is very important for the performance of queries especially when using it with GraphQL.
-Therefor Hypergraph uses officially recommended library
-[dataloader](https://github.com/graphql/dataloader) to gain performance via batching and caching.
+Some TypeORM query methods are not supported in Firestore:
 
-```ts
+| Feature | Support |
+|---------|---------|
+| `whereTextContains` | Not supported |
+| `whereTextEndsWith` | Not supported |
+| Case-insensitive search | Not supported |
+| `whereJoin` | Not supported |
+| `fetchRelation` | Not supported |
+| Soft delete | Not supported |
+| `cache()` | No effect |
+
+## Caching with DataLoader
+
+For GraphQL applications, use the built-in DataLoader integration for batching and caching:
+
+```typescript
 import { RepositoryWithIdCache } from '@hgraph/storage'
 
 class UserRepository extends RepositoryWithIdCache<User> {
@@ -912,11 +535,8 @@ class UserRepository extends RepositoryWithIdCache<User> {
     super(User)
   }
 }
-```
 
-or if you are using firestore do the following
-
-```ts
+// For Firestore
 import { FirestoreRepositoryWithIdCache } from '@hgraph/storage'
 
 class UserRepository extends FirestoreRepositoryWithIdCache<User> {
@@ -926,185 +546,119 @@ class UserRepository extends FirestoreRepositoryWithIdCache<User> {
 }
 ```
 
-Alternatively you can build your own cache-by-a-property using the following code.
+### Custom Cache Key
 
-```ts
-import { Repository, RepositoryOptions, WithCache } from '@hgraph/storage'
-import { ObjectLiteral } from 'typeorm'
-import { ClassType } from 'tsds-tools'
+```typescript
+import { Repository, WithCache } from '@hgraph/storage'
 
-@WithCache('name')
-class RepositoryWithNameCache<Entity extends ObjectLiteral> extends Repository<Entity> {
-  constructor(
-    public readonly entity: ClassType<Entity>,
-    public readonly options?: RepositoryOptions,
-  ) {
-    super(entity, options)
-  }
-}
-
-class UserRepository extends RepositoryWithNameCache<User> {
-  constructor() {
-    super(User)
-  }
-}
-```
-
-For firestore:
-
-```ts
-import {
-  FirestoreRepository,
-  FirestoreRepositoryOptions,
-  WithFirestoreCache,
-} from '@hgraph/storage'
-import { ObjectLiteral } from 'typeorm'
-import { ClassType } from 'tsds-tools'
-
-@WithFirestoreCache('name')
-class FirestoreRepositoryWithNameCache<
-  Entity extends ObjectLiteral,
-> extends FirestoreRepository<Entity> {
-  constructor(
-    public readonly entity: ClassType<Entity>,
-    public readonly options?: FirestoreRepositoryOptions,
-  ) {
-    super(entity, options)
-  }
-}
-
-class UserRepository extends FirestoreRepositoryWithNameCache<User> {
-  constructor() {
-    super(User)
-  }
-}
-```
-
-## TypeORM DataSource
-
-You can access TypeORM DataSource directly, to tap on to any TypeORM feature that is not covered by
-this library by using the following code:
-
-```ts
-import { initializeDataSource } from '@hgraph/storage'
-import { container } from 'tsyringe'
-import { DataSource } from 'typeorm'
-
-async function run() {
-  await initializeDataSource({
-    type: 'postgres',
-    ...
-  })
-
-  const dataSource = container.resolve(DataSource)
+@WithCache('email')
+class RepositoryWithEmailCache<Entity> extends Repository<Entity> {
+  // Cache by email instead of ID
 }
 ```
 
 ## Testing
 
-This package comes with an in-memory implementation of the database based on
-[pg-mem](https://github.com/oguimbal/pg-mem) to support testing. Use `initializeMockDataSource` to
-initialize in-memory database.
+@hgraph/storage includes an in-memory database implementation using [pg-mem](https://github.com/oguimbal/pg-mem) for testing:
 
-```ts
-import { initializeMockDataSource } from '@hgraph/storage/dist/typeorm-mock'
+```typescript
+import { initializeMockDataSource, MockTypeORMDataSource } from '@hgraph/storage/dist/typeorm-mock'
 
-describe('Test suite', () => {
+describe('UserRepository', () => {
   let dataSource: MockTypeORMDataSource
-
-  class UserRepository extends Repository<UserEntity> {
-    constructor() {
-      super(UserEntity)
-    }
-  }
-
-  class PhotoRepository extends Repository<PhotoEntity> {
-    constructor() {
-      super(PhotoEntity)
-    }
-  }
 
   beforeEach(async () => {
     dataSource = await initializeMockDataSource({
       type: 'postgres',
       database: 'test',
-      entities: [UserEntity, PhotoEntity],
+      entities: [User, Post],
       synchronize: false,
-      retry: 0,
     })
-    await container.resolve(UserRepository).saveMany(data.users as any)
-    await container.resolve(PhotoRepository).saveMany(data.photos)
   })
 
   afterEach(async () => {
     dataSource?.destroy()
   })
 
-  test('should pass sanity test', async () => {
-    const repository = container.resolve(PhotoRepository)
-    const result = await repository.count()
-    expect(result).toEqual(data.photos.length)
+  it('should create and find users', async () => {
+    const repo = container.resolve(UserRepository)
+
+    await repo.save({ id: 'user-1', name: 'Test User' })
+
+    const user = await repo.findById('user-1')
+    expect(user?.name).toBe('Test User')
   })
 })
 ```
 
-### Testing with firestore
+### Testing with Firestore
 
-```ts
+```typescript
 import { initializeMockFirestore } from '@hgraph/storage/dist/firestore-repository/firestore-mock'
 
-describe('Test suite', () => {
-  let dataSource: MockTypeORMDataSource
-
-  class UserRepository extends Repository<UserEntity> {
-    constructor() {
-      super(UserEntity)
-    }
-  }
-
-  class PhotoRepository extends Repository<PhotoEntity> {
-    constructor() {
-      super(PhotoEntity)
-    }
-  }
-
-  async function saveAll() {
-    await Promise.all([
-      container.resolve(UserRepository).saveMany(data.users as any),
-      container.resolve(PhotoRepository).saveMany(data.photos),
-    ])
-  }
-
-  async function deleteAll() {
-    await Promise.all([
-      container.resolve(UserRepository).delete(query => query),
-      container.resolve(PhotoRepository).delete(query => query),
-    ])
-  }
-
-  beforeAll(async () => {
-    // OPTION 1: RUN WITH EMULATOR
-    // const firestore = admin.initializeApp({ projectId: 'test-e9d5b' }).firestore()
-    // firestore.settings({ host: 'localhost:8080', ssl: false })
-    // container.registerInstance(FIRESTORE_INSTANCE, firestore)
-
-    // OPTION 2: RUN WITH MOCK
-    initializeMockFirestore()
-  })
-
-  beforeEach(async () => {
-    await deleteAll()
-    await saveAll()
-  })
-
-  afterAll(async () => {
-    await deleteAll()
-  })
-
-  test('should pass sanity test', async () => {
-    const repository = container.resolve(PhotoRepository)
-    const result = await repository.count()
-    expect(result).toEqual(data.photos.length)
-  })
+beforeAll(() => {
+  initializeMockFirestore()
 })
 ```
+
+Or use the Firestore emulator:
+
+```typescript
+import admin from 'firebase-admin'
+import { container } from 'tsyringe'
+import { FIRESTORE_INSTANCE } from '@hgraph/storage'
+
+const firestore = admin.initializeApp({ projectId: 'test' }).firestore()
+firestore.settings({ host: 'localhost:8080', ssl: false })
+container.registerInstance(FIRESTORE_INSTANCE, firestore)
+```
+
+## Advanced Usage
+
+### Access TypeORM DataSource
+
+```typescript
+import { initializeDataSource } from '@hgraph/storage'
+import { container } from 'tsyringe'
+import { DataSource } from 'typeorm'
+
+await initializeDataSource({ type: 'postgres', /* ... */ })
+
+const dataSource = container.resolve(DataSource)
+// Use any TypeORM feature directly
+```
+
+### Entity Examples
+
+See [docs/entities.md](docs/entities.md) for complete entity setup examples including:
+- Basic entities with columns
+- Enums and arrays
+- One-to-many and many-to-one relations
+- Self-referencing relations
+
+## Database Support
+
+Built on [TypeORM](https://typeorm.io/), @hgraph/storage supports:
+
+- PostgreSQL
+- MySQL / MariaDB
+- SQLite
+- Microsoft SQL Server
+- Oracle
+- CockroachDB
+- SAP Hana
+- Cloud Firestore (via dedicated adapter)
+
+## License
+
+MIT
+
+## Contributing
+
+Contributions are welcome! Please read our contributing guidelines before submitting a PR.
+
+## Links
+
+- [GitHub Repository](https://github.com/rintoj/hypergraph-storage)
+- [npm Package](https://www.npmjs.com/package/@hgraph/storage)
+- [TypeORM Documentation](https://typeorm.io/)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ A powerful, type-safe database abstraction layer built on TypeORM with first-cla
 
 - [Installation](#installation)
 - [Quick Start](#quick-start)
-- [Base Entity](#base-entity)
-- [ID Generation](#id-generation)
 - [Usage with NestJS](#usage-with-nestjs)
 - [Usage without NestJS](#usage-without-nestjs)
 - [Query Builder](#query-builder)
@@ -37,6 +35,8 @@ A powerful, type-safe database abstraction layer built on TypeORM with first-cla
   - [Incrementing Values](#incrementing-values)
   - [Deleting and Restoring](#deleting-and-restoring)
 - [Cloud Firestore](#cloud-firestore)
+- [Base Entity](#base-entity)
+- [ID Generation](#id-generation)
 - [Caching with DataLoader](#caching-with-dataloader)
 - [Testing](#testing)
 - [Advanced Usage](#advanced-usage)
@@ -115,78 +115,6 @@ const activeUsers = await userRepo.findAll(q =>
    .whereMoreThan('followers', 100)
    .orderByDescending('followers')
 )
-```
-
-## Base Entity
-
-Instead of manually defining common fields like `id`, `createdAt`, and `updatedAt` on every entity, extend `BaseEntity` to get them automatically. This ensures consistency across your data model and enables features like soft delete and optimistic locking out of the box.
-
-```typescript
-import { BaseEntity } from '@hgraph/storage'
-import { Entity, Column } from 'typeorm'
-
-@Entity()
-class User extends BaseEntity {
-  // Inherited fields:
-  // - id: string (primary key)
-  // - createdAt: Date (auto-set on insert)
-  // - updatedAt: Date (auto-set on update)
-  // - deletedAt: Date (for soft deletes)
-  // - version: number (optimistic locking)
-
-  @Column()
-  name!: string
-
-  @Column()
-  email!: string
-}
-```
-
-The `version` field enables optimistic locking - if two processes try to update the same record simultaneously, the second update will fail rather than silently overwriting changes.
-
-## ID Generation
-
-When you insert records without specifying an ID, the library automatically generates one using `generateId()`. You can also use these utilities directly for custom ID generation needs:
-
-```typescript
-import {
-  generateId,
-  generateNumericId,
-  generateIdOf,
-  createRandomIdGenerator
-} from '@hgraph/storage'
-
-// Generate 8-character alphanumeric ID (default for auto-generated IDs)
-const id = generateId() // e.g., "Ax7kM2pQ"
-
-// Generate numeric timestamp-based ID (useful for sortable IDs)
-const numericId = generateNumericId() // e.g., "7234561234567890"
-
-// Generate deterministic hash-based ID from input (same input = same output)
-// Useful for creating stable IDs from external identifiers
-const hashId = generateIdOf('user@example.com')
-
-// Create custom ID generator with specific length and character set
-const generate12CharId = createRandomIdGenerator(12, 'ABCDEF0123456789')
-const hexId = generate12CharId() // e.g., "A1B2C3D4E5F6"
-```
-
-### Custom ID Generator Decorator
-
-For entities that need specific ID formats (like order numbers or SKUs), use the `@IdGenerator` decorator. The function runs automatically when inserting new records:
-
-```typescript
-import { BaseEntity, IdGenerator } from '@hgraph/storage'
-import { Entity, Column } from 'typeorm'
-
-@Entity()
-@IdGenerator<Order>(order => {
-  order.id = `ORD-${Date.now()}`
-})
-class Order extends BaseEntity {
-  @Column()
-  total!: number
-}
 ```
 
 ## Usage with NestJS
@@ -657,6 +585,78 @@ Some TypeORM query methods are not supported in Firestore:
 | `fetchRelation` | Not supported |
 | Soft delete | Not supported |
 | `cache()` | No effect |
+
+## Base Entity
+
+Instead of manually defining common fields like `id`, `createdAt`, and `updatedAt` on every entity, extend `BaseEntity` to get them automatically. This ensures consistency across your data model and enables features like soft delete and optimistic locking out of the box.
+
+```typescript
+import { BaseEntity } from '@hgraph/storage'
+import { Entity, Column } from 'typeorm'
+
+@Entity()
+class User extends BaseEntity {
+  // Inherited fields:
+  // - id: string (primary key)
+  // - createdAt: Date (auto-set on insert)
+  // - updatedAt: Date (auto-set on update)
+  // - deletedAt: Date (for soft deletes)
+  // - version: number (optimistic locking)
+
+  @Column()
+  name!: string
+
+  @Column()
+  email!: string
+}
+```
+
+The `version` field enables optimistic locking - if two processes try to update the same record simultaneously, the second update will fail rather than silently overwriting changes.
+
+## ID Generation
+
+When you insert records without specifying an ID, the library automatically generates one using `generateId()`. You can also use these utilities directly for custom ID generation needs:
+
+```typescript
+import {
+  generateId,
+  generateNumericId,
+  generateIdOf,
+  createRandomIdGenerator
+} from '@hgraph/storage'
+
+// Generate 8-character alphanumeric ID (default for auto-generated IDs)
+const id = generateId() // e.g., "Ax7kM2pQ"
+
+// Generate numeric timestamp-based ID (useful for sortable IDs)
+const numericId = generateNumericId() // e.g., "7234561234567890"
+
+// Generate deterministic hash-based ID from input (same input = same output)
+// Useful for creating stable IDs from external identifiers
+const hashId = generateIdOf('user@example.com')
+
+// Create custom ID generator with specific length and character set
+const generate12CharId = createRandomIdGenerator(12, 'ABCDEF0123456789')
+const hexId = generate12CharId() // e.g., "A1B2C3D4E5F6"
+```
+
+### Custom ID Generator Decorator
+
+For entities that need specific ID formats (like order numbers or SKUs), use the `@IdGenerator` decorator. The function runs automatically when inserting new records:
+
+```typescript
+import { BaseEntity, IdGenerator } from '@hgraph/storage'
+import { Entity, Column } from 'typeorm'
+
+@Entity()
+@IdGenerator<Order>(order => {
+  order.id = `ORD-${Date.now()}`
+})
+class Order extends BaseEntity {
+  @Column()
+  total!: number
+}
+```
 
 ## Caching with DataLoader
 

--- a/docs/query-builder.md
+++ b/docs/query-builder.md
@@ -1,0 +1,197 @@
+# Query Builder
+
+The `@hgraph/storage` query builder provides a type-safe, fluent API for building database queries with TypeORM.
+
+## Basic Usage
+
+```typescript
+import { Query, PaginatedQuery } from '@hgraph/storage'
+
+// Simple query
+const users = await repository.findOne(
+  q => q.whereEqualTo('status', 'active')
+       .orderByDescending('createdAt')
+)
+
+// Paginated query
+const result = await repository.find(
+  q => q.whereEqualTo('status', 'active')
+       .limit(20)
+)
+```
+
+## Terminal Query Pattern
+
+To prevent "Unsupported FindOperator" errors from TypeORM, the query builder enforces safe ordering of query methods using a **Terminal Query Pattern**.
+
+### What is a Terminal Query?
+
+Certain query methods (`whereIn` and `whereOr`) return a `TerminalQuery` instead of the regular query builder. The `TerminalQuery` only exposes safe methods that can be chained after these operators.
+
+### Why This Matters
+
+TypeORM has limitations with how FindOperators can be combined. Incorrect ordering causes runtime errors like:
+
+```
+TypeError: Unsupported FindOperator Function
+```
+
+The Terminal Query Pattern prevents these errors at **compile time**.
+
+## Rules
+
+### Rule 1: `whereIn` Must Be Last
+
+`whereIn()` returns a `TerminalQuery`, so no other where methods can be chained after it.
+
+```typescript
+// CORRECT - whereIn is last
+q.whereEqualTo('status', 'active')
+ .fetchRelation('user')
+ .orderByDescending('createdAt')
+ .whereIn('groupId', groupIds)
+
+// COMPILE ERROR - can't chain whereEqualTo after whereIn
+q.whereIn('groupId', groupIds)
+ .whereEqualTo('status', 'active')  // TypeScript error!
+```
+
+### Rule 2: `whereOr` Must Be Last
+
+`whereOr()` also returns a `TerminalQuery`.
+
+```typescript
+// CORRECT - whereOr is last
+q.whereEqualTo('status', 'active')
+ .whereOr(
+   q1 => q1.whereEqualTo('role', 'admin'),
+   q2 => q2.whereEqualTo('role', 'moderator')
+ )
+
+// COMPILE ERROR - can't chain after whereOr
+q.whereOr(
+   q1 => q1.whereEqualTo('role', 'admin'),
+   q2 => q2.whereEqualTo('role', 'moderator')
+ )
+ .whereEqualTo('status', 'active')  // TypeScript error!
+```
+
+### Rule 3: Never Use `whereIn` Inside `whereJoin`
+
+This throws a runtime error with a helpful message.
+
+```typescript
+// RUNTIME ERROR
+q.whereJoin('group', gq => gq.whereIn('id', groupIds))
+
+// CORRECT - use explicit foreign key
+q.whereIn('groupId', groupIds)
+```
+
+### Rule 4: Never Use `whereIn` Inside `whereOr`
+
+This throws a runtime error with a helpful message.
+
+```typescript
+// RUNTIME ERROR
+q.whereOr(
+  q1 => q1.whereIn('status', ['active', 'pending']),
+  q2 => q2.whereEqualTo('role', 'admin')
+)
+
+// CORRECT - restructure with multiple whereEqualTo
+q.whereOr(
+  q1 => q1.whereEqualTo('status', 'active'),
+  q2 => q2.whereEqualTo('status', 'pending'),
+  q3 => q3.whereEqualTo('role', 'admin')
+)
+```
+
+### Rule 5: Combining AND with OR
+
+To combine AND conditions with OR, include the AND condition inside each OR branch:
+
+```typescript
+// CORRECT - AND condition inside each branch
+q.whereOr(
+  q1 => q1.whereEqualTo('age', 48).whereTextContains('gender', 'Male'),
+  q2 => q2.whereEqualTo('age', 64).whereTextContains('gender', 'Male')
+)
+```
+
+## Safe Query Pattern
+
+Follow this recommended order for building queries:
+
+```typescript
+q.whereJoin('relation', rq => rq.whereEqualTo('field', value))  // 1. Joins first
+ .whereEqualTo('field1', value1)                                 // 2. Simple equality
+ .whereNotEqualTo('field2', value2)                              // 3. Simple inequality
+ .whereMoreThan('field3', value3)                                // 4. Comparisons
+ .whereTextInAnyCaseContains('field4', value4)                   // 5. Text search
+ .whereIsNotNull('field5')                                       // 6. Null checks
+ .fetchRelation('otherRelation')                                 // 7. Fetch relations
+ .orderByDescending('createdAt')                                 // 8. Sorting
+ .limit(50)                                                      // 9. Pagination
+ .whereIn('field6', values)                                      // 10. LAST: whereIn
+```
+
+## Methods Available After Terminal Operations
+
+After calling `whereIn()` or `whereOr()`, you can still chain these safe methods:
+
+- `orderByAscending(key)` / `orderByDescending(key)`
+- `select(key)`
+- `fetchRelation(key1, key2?, key3?, key4?)`
+- `loadRelationIds()`
+- `cache(boolean | number)`
+- `toQuery()`
+
+For paginated queries (`TerminalPaginatedQuery`):
+- `limit(count)`
+- `next(token)`
+- `pagination({ next?, limit? })`
+
+## Available Where Methods
+
+### Comparison Operators
+- `whereEqualTo(key, value)` - Equality check
+- `whereNotEqualTo(key, value)` - Not equal
+- `whereMoreThan(key, value)` - Greater than
+- `whereMoreThanOrEqual(key, value)` - Greater than or equal
+- `whereLessThan(key, value)` - Less than
+- `whereLessThanOrEqual(key, value)` - Less than or equal
+- `whereBetween(key, from, to)` - Range check
+
+### Text Search
+- `whereTextContains(key, value)` - LIKE '%value%'
+- `whereTextStartsWith(key, value)` - LIKE 'value%'
+- `whereTextEndsWith(key, value)` - LIKE '%value'
+- `whereTextInAnyCaseContains(key, value)` - Case-insensitive contains
+- `whereTextInAnyCaseStartsWith(key, value)` - Case-insensitive starts with
+- `whereTextInAnyCaseEndsWith(key, value)` - Case-insensitive ends with
+
+### Array and Null
+- `whereIn(key, values)` - IN operator (**Terminal**)
+- `whereArrayContains(key, value)` - Array contains value
+- `whereArrayContainsAny(key, values)` - Array contains any
+- `whereIsNull(key)` - IS NULL
+- `whereIsNotNull(key)` - IS NOT NULL
+
+### Complex Conditions
+- `whereJoin(key, queryBuilder)` - Join conditions
+- `whereOr(q1, q2, ...others)` - OR logic (**Terminal**)
+
+## Type Exports
+
+```typescript
+import {
+  Query,
+  PaginatedQuery,
+  QueryWithWhere,
+  TerminalQuery,
+  TerminalPaginatedQuery,
+  isQuery,
+  isTerminalQuery,
+} from '@hgraph/storage'
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hgraph/storage",
-  "version": "1.3.5",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "TypeORM based repository implementation for accessing data storages",

--- a/src/data-source/initialize-datasource.ts
+++ b/src/data-source/initialize-datasource.ts
@@ -58,6 +58,6 @@ export async function initializeDataSource(options: InitializeDataSourceOptions 
       console.log(`(${retry} more attempts) trying to reconnect to database!`, dataSourceOptions),
   })
   container.registerInstance(DataSource, dataSource)
-  
+
   return dataSource
 }

--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -1,1 +1,11 @@
-export * from './query'
+export {
+  DEFAULT_CACHE_TIME,
+  DEFAULT_PAGE_SIZE,
+  isQuery,
+  isTerminalQuery,
+  PaginatedQuery,
+  Query,
+  QueryWithWhere,
+  TerminalPaginatedQuery,
+  TerminalQuery,
+} from './query'

--- a/src/query/query.test.ts
+++ b/src/query/query.test.ts
@@ -329,9 +329,9 @@ describe('Query', () => {
   describe('Terminal Query Enforcement', () => {
     it('should throw error when whereIn is used inside whereJoin', () => {
       const repo = new UserRepository()
-      expect(() =>
-        new Query(repo).whereJoin('photos', q => q.whereIn('id', ['1', '2'])),
-      ).toThrow('whereIn() cannot be used inside whereJoin()')
+      expect(() => new Query(repo).whereJoin('photos', q => q.whereIn('id', ['1', '2']))).toThrow(
+        'whereIn() cannot be used inside whereJoin()',
+      )
     })
 
     it('should throw error when whereIn is used inside whereOr', () => {

--- a/src/query/query.test.ts
+++ b/src/query/query.test.ts
@@ -325,4 +325,67 @@ describe('Query', () => {
     const repo = new UserRepository()
     expect(new Query(repo).loadRelationIds().toQuery().loadRelationIds).toEqual(true)
   })
+
+  describe('Terminal Query Enforcement', () => {
+    it('should throw error when whereIn is used inside whereJoin', () => {
+      const repo = new UserRepository()
+      expect(() =>
+        new Query(repo).whereJoin('photos', q => q.whereIn('id', ['1', '2'])),
+      ).toThrow('whereIn() cannot be used inside whereJoin()')
+    })
+
+    it('should throw error when whereIn is used inside whereOr', () => {
+      const repo = new UserRepository()
+      expect(() =>
+        new Query(repo).whereOr(
+          q => q.whereIn('name', ['John', 'Doe']),
+          q => q.whereEqualTo('id', '1'),
+        ),
+      ).toThrow('whereIn() cannot be used inside whereOr()')
+    })
+
+    it('should return TerminalQuery from whereIn', () => {
+      const repo = new UserRepository()
+      const result = new Query(repo).whereIn('name', ['John', 'Doe'])
+      expect(result.constructor.name).toEqual('TerminalQuery')
+      expect(result.toQuery()).toBeDefined()
+    })
+
+    it('should return TerminalQuery from whereOr', () => {
+      const repo = new UserRepository()
+      const result = new Query(repo).whereOr(
+        q => q.whereEqualTo('id', '1'),
+        q => q.whereEqualTo('id', '2'),
+      )
+      expect(result.constructor.name).toEqual('TerminalQuery')
+      expect(result.toQuery()).toBeDefined()
+    })
+
+    it('should allow chaining safe methods after whereIn', () => {
+      const repo = new UserRepository()
+      const result = new Query(repo)
+        .whereIn('name', ['John', 'Doe'])
+        .orderByAscending('name')
+        .fetchRelation('photos')
+        .cache(false)
+        .toQuery()
+      expect(result.order).toEqual({ name: 'ASC' })
+      expect(result.relations).toEqual({ photos: true })
+      expect(result.cache).toEqual(false)
+    })
+
+    it('should allow chaining safe methods after whereOr', () => {
+      const repo = new UserRepository()
+      const result = new Query(repo)
+        .whereOr(
+          q => q.whereEqualTo('id', '1'),
+          q => q.whereEqualTo('id', '2'),
+        )
+        .orderByDescending('createdAt')
+        .select('id')
+        .toQuery()
+      expect(result.order).toEqual({ createdAt: 'DESC' })
+      expect(result.select).toEqual({ id: true })
+    })
+  })
 })

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -35,16 +35,136 @@ export const DEFAULT_CACHE_TIME = 5 * 1000 // 5 seconds
 
 type QueryBuilder<Entity extends ObjectLiteral> = (
   q: QueryWithWhere<Entity>,
-) => QueryWithWhere<Entity>
+) => QueryWithWhere<Entity> | TerminalQuery<Entity>
+
+/**
+ * Context flags to track query building state for runtime validation
+ */
+interface QueryContext {
+  insideWhereJoin: boolean
+  insideWhereOr: boolean
+}
 
 export function isQuery<T extends ObjectLiteral>(query: any): query is Query<T> {
   return typeof query === 'object' && typeof query?.toQuery === 'function'
+}
+
+export function isTerminalQuery<T extends ObjectLiteral>(query: any): query is TerminalQuery<T> {
+  return query instanceof TerminalQuery
+}
+
+/**
+ * Terminal query class - returned by whereIn() and whereOr().
+ * Only exposes safe methods that can be chained after terminal operators.
+ * This prevents unsafe patterns like chaining whereEqualTo() after whereIn().
+ */
+export class TerminalQuery<Entity extends ObjectLiteral> {
+  protected query: FindManyOptions<Entity> = {
+    cache: DEFAULT_CACHE_TIME,
+    take: DEFAULT_PAGE_SIZE,
+  }
+
+  constructor(public readonly repository: Repository<Entity>) {}
+
+  static from<Entity extends ObjectLiteral>(
+    source: QueryWithWhere<Entity> | Query<Entity> | PaginatedQuery<Entity> | TerminalQuery<Entity>,
+  ): TerminalQuery<Entity> {
+    const newQuery = new TerminalQuery(source.repository)
+    newQuery.query = source.toQuery()
+    return newQuery
+  }
+
+  orderByAscending<Key extends KeysOf<Entity, NonArrayPrimitive>>(key: Key) {
+    this.query = setProperty(['order', key].join('.'), 'ASC', this.query)
+    return this
+  }
+
+  orderByDescending<Key extends KeysOf<Entity, NonArrayPrimitive>>(key: Key) {
+    this.query = setProperty(['order', key].join('.'), 'DESC', this.query)
+    return this
+  }
+
+  select<Key extends KeysOf<Entity, Primitive>>(key: Key) {
+    this.query = setProperty(['select', key].filter(isDefined).join('.'), true, this.query)
+    return this
+  }
+
+  fetchRelation<
+    Key1 extends KeysOfNonPrimitives<Entity>,
+    Key2 extends KeysOfNonPrimitives<InferredType<Entity, Key1>>,
+    Key3 extends KeysOfNonPrimitives<InferredType<InferredType<Entity, Key1>, Key2>>,
+    Key4 extends KeysOfNonPrimitives<
+      InferredType<InferredType<InferredType<Entity, Key1>, Key2>, Key3>
+    >,
+  >(key1: Key1, key2?: Key2, key3?: Key3, key4?: Key4) {
+    this.query = setProperty(
+      ['relations', key1, key2, key3, key4].filter(isDefined).join('.'),
+      true,
+      this.query,
+    )
+    return this
+  }
+
+  loadRelationIds(loadRelationIds = true) {
+    this.query.loadRelationIds = loadRelationIds
+    return this
+  }
+
+  cache(cache: boolean | number = DEFAULT_CACHE_TIME) {
+    this.query.cache = cache
+    return this
+  }
+
+  toQuery() {
+    return this.query
+  }
+}
+
+/**
+ * Terminal paginated query - returned by whereIn() and whereOr() on PaginatedQuery.
+ * Extends TerminalQuery with pagination methods.
+ */
+export class TerminalPaginatedQuery<Entity extends ObjectLiteral> extends TerminalQuery<Entity> {
+  static from<Entity extends ObjectLiteral>(
+    source:
+      | QueryWithWhere<Entity>
+      | Query<Entity>
+      | PaginatedQuery<Entity>
+      | TerminalQuery<Entity>,
+  ): TerminalPaginatedQuery<Entity> {
+    const newQuery = new TerminalPaginatedQuery(source.repository)
+    newQuery.query = source.toQuery()
+    return newQuery
+  }
+
+  pagination(pagination: { next?: string | null; limit?: number | null } | null | undefined) {
+    if (!pagination) return this
+    return this.next(pagination?.next).limit(pagination?.limit)
+  }
+
+  next(next: string | null | undefined) {
+    const [skip, take] = decodeNextToken(next) ?? []
+    this.query.skip = skip
+    this.query.take = take ?? this.query.take ?? DEFAULT_PAGE_SIZE
+    return this
+  }
+
+  limit(limit: number | null | undefined) {
+    if (!limit) return this
+    this.query.take = limit
+    return this
+  }
 }
 
 export class QueryWithWhere<Entity extends ObjectLiteral> {
   protected query: FindManyOptions<Entity> = {
     cache: DEFAULT_CACHE_TIME,
     take: DEFAULT_PAGE_SIZE,
+  }
+
+  protected context: QueryContext = {
+    insideWhereJoin: false,
+    insideWhereOr: false,
   }
 
   constructor(public readonly repository: Repository<Entity>) {}
@@ -183,8 +303,23 @@ export class QueryWithWhere<Entity extends ObjectLiteral> {
   whereIn<Key extends KeysOf<Entity, NonArrayPrimitive>>(
     key: Key,
     value: TypeOf<Entity, Key>[] | undefined,
-  ) {
-    return this.setWhere(key, In(value ?? []))
+  ): TerminalQuery<Entity> {
+    if (this.context.insideWhereJoin) {
+      throw new Error(
+        'whereIn() cannot be used inside whereJoin(). Use the explicit foreign key field instead. ' +
+          'Example: Instead of q.whereJoin("group", gq => gq.whereIn("id", ids)), ' +
+          'use q.whereIn("groupId", ids)',
+      )
+    }
+    if (this.context.insideWhereOr) {
+      throw new Error(
+        'whereIn() cannot be used inside whereOr(). Restructure your query to use multiple ' +
+          'whereEqualTo() conditions instead. Example: Instead of whereOr(q => q.whereIn("status", ["a", "b"])), ' +
+          'use whereOr(q => q.whereEqualTo("status", "a"), q => q.whereEqualTo("status", "b"))',
+      )
+    }
+    this.setWhere(key, In(value ?? []))
+    return TerminalQuery.from(this)
   }
 
   whereIsNull<Key extends KeysOf<Entity>>(key: Key) {
@@ -214,12 +349,13 @@ export class QueryWithWhere<Entity extends ObjectLiteral> {
     Type extends InferredType<Entity, Key> & ObjectLiteral,
   >(key: Key, queryBuilder: QueryBuilder<Type>) {
     const query = new Query<any>(this.repository)
+    query.context.insideWhereJoin = true
     const result = (queryBuilder(query) as Query<Type>).toQuery() as FindManyOptions<Entity>
     this.query = setProperty(['relations', key].join('.'), result.relations ?? true, this.query)
     return this.setWhere(key, result.where)
   }
 
-  private setWhere<Key extends KeysOf<Entity>>(
+  protected setWhere<Key extends KeysOf<Entity>>(
     key: Key,
     where:
       | FindOperator<any>
@@ -242,15 +378,16 @@ export class QueryWithWhere<Entity extends ObjectLiteral> {
     queryBuilder1: QueryBuilder<Entity>,
     queryBuilder2: QueryBuilder<Entity>,
     ...otherQueryBuilder: QueryBuilder<Entity>[]
-  ) {
+  ): TerminalQuery<Entity> {
     const queryBuilders = [queryBuilder1, queryBuilder2, ...otherQueryBuilder].filter(isDefined)
     const results = queryBuilders.map(queryBuilder => {
       const query = new Query<Entity>(this.repository)
       query.query.where = this.query.where
+      query.context.insideWhereOr = true
       return queryBuilder(query).toQuery().where
     })
     this.query = setProperty('where', results.filter(isDefined), this.query)
-    return this as any
+    return TerminalQuery.from(this)
   }
 
   toQuery() {
@@ -311,9 +448,14 @@ export class Query<Entity extends ObjectLiteral> extends QueryWithWhere<Entity> 
 }
 
 export class PaginatedQuery<Entity extends ObjectLiteral> extends Query<Entity> {
-  static from<QueryType extends QueryWithWhere<any> | Query<any> | PaginatedQuery<any>>(
-    query: QueryType,
-  ): PaginatedQuery<any> {
+  static from<
+    QueryType extends
+      | QueryWithWhere<any>
+      | Query<any>
+      | PaginatedQuery<any>
+      | TerminalQuery<any>
+      | TerminalPaginatedQuery<any>,
+  >(query: QueryType): PaginatedQuery<any> {
     const newQuery: any = new PaginatedQuery(query.repository)
     newQuery.query = query.toQuery()
     return newQuery as PaginatedQuery<any>
@@ -335,5 +477,43 @@ export class PaginatedQuery<Entity extends ObjectLiteral> extends Query<Entity> 
     if (!limit) return this
     this.query.take = limit
     return this
+  }
+
+  override whereIn<Key extends KeysOf<Entity, NonArrayPrimitive>>(
+    key: Key,
+    value: TypeOf<Entity, Key>[] | undefined,
+  ): TerminalPaginatedQuery<Entity> {
+    if (this.context.insideWhereJoin) {
+      throw new Error(
+        'whereIn() cannot be used inside whereJoin(). Use the explicit foreign key field instead. ' +
+          'Example: Instead of q.whereJoin("group", gq => gq.whereIn("id", ids)), ' +
+          'use q.whereIn("groupId", ids)',
+      )
+    }
+    if (this.context.insideWhereOr) {
+      throw new Error(
+        'whereIn() cannot be used inside whereOr(). Restructure your query to use multiple ' +
+          'whereEqualTo() conditions instead. Example: Instead of whereOr(q => q.whereIn("status", ["a", "b"])), ' +
+          'use whereOr(q => q.whereEqualTo("status", "a"), q => q.whereEqualTo("status", "b"))',
+      )
+    }
+    this.setWhere(key, In(value ?? []))
+    return TerminalPaginatedQuery.from(this)
+  }
+
+  override whereOr(
+    queryBuilder1: QueryBuilder<Entity>,
+    queryBuilder2: QueryBuilder<Entity>,
+    ...otherQueryBuilder: QueryBuilder<Entity>[]
+  ): TerminalPaginatedQuery<Entity> {
+    const queryBuilders = [queryBuilder1, queryBuilder2, ...otherQueryBuilder].filter(isDefined)
+    const results = queryBuilders.map(queryBuilder => {
+      const subQuery = new PaginatedQuery<Entity>(this.repository)
+      subQuery.query.where = this.query.where
+      subQuery.context.insideWhereOr = true
+      return queryBuilder(subQuery).toQuery().where
+    })
+    this.query = setProperty('where', results.filter(isDefined), this.query)
+    return TerminalPaginatedQuery.from(this)
   }
 }

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -126,11 +126,7 @@ export class TerminalQuery<Entity extends ObjectLiteral> {
  */
 export class TerminalPaginatedQuery<Entity extends ObjectLiteral> extends TerminalQuery<Entity> {
   static from<Entity extends ObjectLiteral>(
-    source:
-      | QueryWithWhere<Entity>
-      | Query<Entity>
-      | PaginatedQuery<Entity>
-      | TerminalQuery<Entity>,
+    source: QueryWithWhere<Entity> | Query<Entity> | PaginatedQuery<Entity> | TerminalQuery<Entity>,
   ): TerminalPaginatedQuery<Entity> {
     const newQuery = new TerminalPaginatedQuery(source.repository)
     newQuery.query = source.toQuery()

--- a/src/repository/repository.ts
+++ b/src/repository/repository.ts
@@ -9,11 +9,7 @@ import {
   toPaginationToken,
 } from '../pagination'
 import { DEFAULT_PAGE_SIZE, isQuery, Query, QueryWithWhere } from '../query'
-import {
-  PaginatedQuery,
-  TerminalPaginatedQuery,
-  TerminalQuery,
-} from '../query/query'
+import { PaginatedQuery, TerminalPaginatedQuery, TerminalQuery } from '../query/query'
 
 export type EntityWithOptionalId<Entity> = Omit<Entity, 'id'> & { id?: string }
 export type PartialEntityWithId<Entity> = DeepPartial<Entity> & { id: string }
@@ -78,7 +74,9 @@ export class Repository<Entity extends ObjectLiteral> {
     queryOrCallback?:
       | PaginatedQuery<Entity>
       | TerminalPaginatedQuery<Entity>
-      | ((query: PaginatedQuery<Entity>) => PaginatedQuery<Entity> | TerminalPaginatedQuery<Entity>),
+      | ((
+          query: PaginatedQuery<Entity>,
+        ) => PaginatedQuery<Entity> | TerminalPaginatedQuery<Entity>),
     filter?: PaginationFilter<Entity>,
     onPage?: OnPageLoad<Entity>,
   ): Promise<Entity[]> {
@@ -93,7 +91,9 @@ export class Repository<Entity extends ObjectLiteral> {
     queryOrCallback:
       | PaginatedQuery<Entity>
       | TerminalPaginatedQuery<Entity>
-      | ((query: PaginatedQuery<Entity>) => PaginatedQuery<Entity> | TerminalPaginatedQuery<Entity>),
+      | ((
+          query: PaginatedQuery<Entity>,
+        ) => PaginatedQuery<Entity> | TerminalPaginatedQuery<Entity>),
   ): Promise<PaginatedResult<Entity>> {
     const query =
       typeof queryOrCallback === 'function'
@@ -191,8 +191,8 @@ export class Repository<Entity extends ObjectLiteral> {
     const where = hasToQuery(queryOrId)
       ? queryOrId.toQuery().where
       : queryOrId instanceof Array
-        ? new QueryWithWhere(this).whereIn('id' as any, queryOrId as any[]).toQuery().where
-        : new QueryWithWhere(this).whereEqualTo('id' as any, queryOrId as any).toQuery().where
+      ? new QueryWithWhere(this).whereIn('id' as any, queryOrId as any[]).toQuery().where
+      : new QueryWithWhere(this).whereEqualTo('id' as any, queryOrId as any).toQuery().where
     if (!where) throw new Error('Invalid query: no WHERE condition!')
     if (hasToQuery(queryOrId) && where instanceof Array) {
       const items = await paginate(next =>

--- a/src/repository/repository.ts
+++ b/src/repository/repository.ts
@@ -9,7 +9,11 @@ import {
   toPaginationToken,
 } from '../pagination'
 import { DEFAULT_PAGE_SIZE, isQuery, Query, QueryWithWhere } from '../query'
-import { PaginatedQuery } from '../query/query'
+import {
+  PaginatedQuery,
+  TerminalPaginatedQuery,
+  TerminalQuery,
+} from '../query/query'
 
 export type EntityWithOptionalId<Entity> = Omit<Entity, 'id'> & { id?: string }
 export type PartialEntityWithId<Entity> = DeepPartial<Entity> & { id: string }
@@ -17,7 +21,8 @@ export type IdsOrQuery<Entity extends ObjectLiteral> =
   | string
   | string[]
   | QueryWithWhere<Entity>
-  | ((query: Query<Entity>) => Query<Entity>)
+  | TerminalQuery<Entity>
+  | ((query: Query<Entity>) => Query<Entity> | TerminalQuery<Entity>)
 
 export interface DeleteOptions {
   softDelete?: boolean
@@ -38,7 +43,7 @@ export class Repository<Entity extends ObjectLiteral> {
     return dataSource.getRepository(this.entity)
   }
 
-  count(query?: QueryWithWhere<Entity>): Promise<number> {
+  count(query?: QueryWithWhere<Entity> | TerminalQuery<Entity>): Promise<number> {
     return this.repository.count(query?.toQuery())
   }
 
@@ -48,15 +53,19 @@ export class Repository<Entity extends ObjectLiteral> {
   }
 
   async findByIds(ids: string[]): Promise<Array<Entity | null>> {
-    const items = await paginate(next =>
-      this.find(new PaginatedQuery<any>(this).whereIn('id', ids).next(next)),
-    )
+    const items = await paginate(next => {
+      const terminalQuery = new PaginatedQuery<any>(this).whereIn('id', ids)
+      return this.find(TerminalPaginatedQuery.from(terminalQuery).next(next))
+    })
     const itemsById = toByProperty(items, 'id')
     return ids.map(id => itemsById[id] ?? null)
   }
 
   findOne(
-    queryOrCallback?: Query<Entity> | ((query: Query<Entity>) => Query<Entity>),
+    queryOrCallback?:
+      | Query<Entity>
+      | TerminalQuery<Entity>
+      | ((query: Query<Entity>) => Query<Entity> | TerminalQuery<Entity>),
   ): Promise<Entity | null> {
     const query =
       typeof queryOrCallback === 'function' ? queryOrCallback(new Query(this)) : queryOrCallback
@@ -68,7 +77,8 @@ export class Repository<Entity extends ObjectLiteral> {
   async findAll(
     queryOrCallback?:
       | PaginatedQuery<Entity>
-      | ((query: PaginatedQuery<Entity>) => PaginatedQuery<Entity>),
+      | TerminalPaginatedQuery<Entity>
+      | ((query: PaginatedQuery<Entity>) => PaginatedQuery<Entity> | TerminalPaginatedQuery<Entity>),
     filter?: PaginationFilter<Entity>,
     onPage?: OnPageLoad<Entity>,
   ): Promise<Entity[]> {
@@ -76,13 +86,14 @@ export class Repository<Entity extends ObjectLiteral> {
       (typeof queryOrCallback === 'function'
         ? queryOrCallback(new PaginatedQuery(this))
         : queryOrCallback) ?? new PaginatedQuery(this)
-    return paginate(next => this.find(query.next(next)), filter, onPage)
+    return paginate(next => this.find(PaginatedQuery.from(query).next(next)), filter, onPage)
   }
 
   async find(
     queryOrCallback:
       | PaginatedQuery<Entity>
-      | ((query: PaginatedQuery<Entity>) => PaginatedQuery<Entity>),
+      | TerminalPaginatedQuery<Entity>
+      | ((query: PaginatedQuery<Entity>) => PaginatedQuery<Entity> | TerminalPaginatedQuery<Entity>),
   ): Promise<PaginatedResult<Entity>> {
     const query =
       typeof queryOrCallback === 'function'
@@ -175,14 +186,18 @@ export class Repository<Entity extends ObjectLiteral> {
   ): Promise<FindOptionsWhere<any> | undefined> {
     const queryOrId =
       typeof queryOrCallback === 'function' ? queryOrCallback(new Query(this)) : queryOrCallback
-    const where = isQuery(queryOrId)
+    const hasToQuery = (q: any): q is { toQuery: () => any } =>
+      typeof q === 'object' && typeof q?.toQuery === 'function'
+    const where = hasToQuery(queryOrId)
       ? queryOrId.toQuery().where
       : queryOrId instanceof Array
-      ? new QueryWithWhere(this).whereIn('id' as any, queryOrId as any[]).toQuery().where
-      : new QueryWithWhere(this).whereEqualTo('id' as any, queryOrId as any).toQuery().where
+        ? new QueryWithWhere(this).whereIn('id' as any, queryOrId as any[]).toQuery().where
+        : new QueryWithWhere(this).whereEqualTo('id' as any, queryOrId as any).toQuery().where
     if (!where) throw new Error('Invalid query: no WHERE condition!')
-    if (isQuery(queryOrId) && where instanceof Array) {
-      const items = await paginate(next => this.find(PaginatedQuery.from(queryOrId).next(next)))
+    if (hasToQuery(queryOrId) && where instanceof Array) {
+      const items = await paginate(next =>
+        this.find(TerminalPaginatedQuery.from(queryOrId).next(next)),
+      )
       if (!items.length) return undefined
       return this.toFindOptionsWhere(items.map(i => i.id))
     }


### PR DESCRIPTION
## Summary

- Implements Terminal Query Pattern to enforce query chain ordering at compile time
- `whereIn()` and `whereOr()` now return `TerminalQuery`/`TerminalPaginatedQuery` types that only expose safe methods
- Adds runtime validation to prevent `whereIn()` inside `whereJoin()` or `whereOr()`
- Bumps version to 2.0.0 (breaking change)

## Breaking Changes

- `whereIn()` must be last in query chain (no more where clauses can be added after)
- `whereOr()` must be last in query chain (no more where clauses can be added after)
- `whereIn()` inside `whereJoin()` throws runtime error
- `whereIn()` inside `whereOr()` throws runtime error

## Migration Guide

Reorder query chains to place `whereIn()`/`whereOr()` last:

```typescript
// Before (will now cause TypeScript error)
q.whereIn('status', statuses).whereEqualTo('active', true)

// After
q.whereEqualTo('active', true).whereIn('status', statuses)
```

## Test plan

- [x] All 177 existing tests pass
- [x] New tests added for TerminalQuery and TerminalPaginatedQuery
- [x] Runtime validation tests for whereIn inside whereJoin/whereOr
- [x] Verified compile-time error in consuming project (kudzu)